### PR TITLE
Fixes: Could not find a declaration file for module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A vite-plugin to encapsulate and scope your TailwindCSS styles to your library and prevent them affecting styles outside",
   "version": "2.0.1",
   "main": "./dist/cjs/index.cjs",
-  "types": "./dist/main.d.ts",
+  "types": "./dist/src/main.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
~~might fix~~ fixes #5 (tested it) declaration issue. `main.d.ts` is located under dist/src in my case of the module: `vite-plugin-scope-tailwind `.

Current error message when importing:
`Could not find a declaration file for module 'vite-plugin-scope-tailwind'. '/..../node_modules/vite-plugin-scope-tailwind/dist/cjs/index.cjs' implicitly has an 'any' type.`